### PR TITLE
replace unmaintainded kartoza/qgis image

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -345,7 +345,7 @@
                                     <a href="https://github.com/qgis/QGIS/"><i class="fab fa-github"></i></a>
                                 </td>
                                 <td title="Docker image">
-                                    <a href="https://hub.docker.com/r/kartoza/qgis-server"><i class="fab fa-docker"></i></a>
+                                    <a href="https://hub.docker.com/r/opengisch/qgis-server"><i class="fab fa-docker"></i></a>
                                 </td>
                                 <td title="Tutorial/Example">
                                     <a href="https://docs.qgis.org/testing/en/docs/server_manual/services.html#wfs3-ogc-api-features">


### PR DESCRIPTION
opengisch/qgis-server image will probably become the official qgis/qgis-server image (QGIS PSC decision pending)